### PR TITLE
HeartBtInt now using specified FIX version when creating a message

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Connect over TCP socket (as client):
 ```javascript
 import FIXParser from 'fixparser';
 const fixParser = new FIXParser();
-fixParser.connect('localhost', 9878, 'BANZAI', 'EXEC');
+fixParser.connect({ host: 'localhost', port: 9878, sender: 'BANZAI', target: 'EXEC', fixVersion: 'FIX.4.4' });
 fixParser.on('open', () => {
     // Connection is open... 
 });

--- a/examples/example_executor.js
+++ b/examples/example_executor.js
@@ -15,7 +15,6 @@ const TARGET = 'EXEC';
 
 function sendLogon() {
     const logon = fixParser.createMessage(
-        new Field(Fields.BeginString, 'FIX.4.2'),
         new Field(Fields.MsgType, Messages.Logon),
         new Field(Fields.MsgSeqNum, fixParser.getNextTargetMsgSeqNum()),
         new Field(Fields.SenderCompID, SENDER),
@@ -30,7 +29,7 @@ function sendLogon() {
     fixParser.send(logon);
 }
 
-fixParser.connect('localhost', 9878, SENDER, TARGET);
+fixParser.connect({ host: 'localhost', port: 9878, sender: SENDER, target: TARGET, fixVersion: 'FIX.4.4' });
 
 fixParser.on('open', () => {
     console.log('Open');
@@ -39,7 +38,6 @@ fixParser.on('open', () => {
 
     setInterval(() => {
         const order = fixParser.createMessage(
-            new Field(Fields.BeginString, 'FIX.4.2'),
             new Field(Fields.MsgType, Messages.NewOrderSingle),
             new Field(Fields.MsgSeqNum, fixParser.getNextTargetMsgSeqNum()),
             new Field(Fields.SenderCompID, SENDER),

--- a/src/FIXParser.js
+++ b/src/FIXParser.js
@@ -34,6 +34,7 @@ export default class FIXParser extends EventEmitter {
         this.messageSequence = 1;
         this.heartBeatInterval = null;
         this.heartBeatIntervalId = null;
+        this.fixVersion = 'FIX.5.0SP2';
     }
 
     stopHeartbeat() {
@@ -55,12 +56,13 @@ export default class FIXParser extends EventEmitter {
         }, this.heartBeatInterval);
     }
 
-    connect(host = 'localhost', port = '9878', sender = 'SENDER', target = 'TARGET', heartbeatIntervalMs = 60000) {
+    connect({ host = 'localhost', port = '9878', sender = 'SENDER', target = 'TARGET', heartbeatIntervalMs = 60000, fixVersion = this.fixVersion } = {}) {
         this.host = host;
         this.port = port;
         this.sender = sender;
         this.target = target;
         this.heartBeatInterval = heartbeatIntervalMs;
+        this.fixVersion = fixVersion;
         this.socket = new Socket();
         this.socket.setEncoding('ascii');
 
@@ -99,7 +101,7 @@ export default class FIXParser extends EventEmitter {
     }
 
     createMessage(...fields) {
-        return new Message(...fields);
+        return new Message(this.fixVersion, ...fields);
     }
 
     parse(data) {

--- a/src/message/Message.js
+++ b/src/message/Message.js
@@ -189,12 +189,19 @@ export default class Message {
         const fields = this.data.map((field) => new Field(field.tag, field.value));
         const data = [];
 
-        const beginString = new Field(BeginString, this.fixVersion).toString();
+        let beginString = new Field(BeginString, this.fixVersion).toString();
         let bodyLength = new Field(BodyLength, MARKER_BODYLENGTH).toString();
         let checksum = new Field(CheckSum, MARKER_CHECKSUM).toString();
+        let index = fields.findIndex((field) => field.tag === BeginString);
+
+        // Check for header
+        if (index > -1) {
+            beginString = fields[index].toString();
+            fields.splice(index, 1);
+        }
 
         // Check for body length
-       let index = fields.findIndex((field) => field.tag === BodyLength);
+       index = fields.findIndex((field) => field.tag === BodyLength);
         if(index > -1) {
             bodyLength = fields[index].toString();
             fields.splice(index, 1);

--- a/src/message/Message.js
+++ b/src/message/Message.js
@@ -16,7 +16,6 @@ import {
     TimeInForce
 } from './../constants/ConstantsField';
 
-const DEFAULT_FIX_VERSION = 'FIX.5.0SP2';
 const TAG_CHECKSUM = '10=';
 const TAG_MSGTYPE = '35=';
 const MARKER_BODYLENGTH = '\x02';
@@ -57,7 +56,8 @@ export default class Message {
         return paddedString.substr(paddedString.length - size);
     }
 
-    constructor(...fields) {
+    constructor(fixVersion, ...fields) {
+        this.fixVersion = fixVersion;
         this.reset();
 
         // Add other tags
@@ -189,19 +189,12 @@ export default class Message {
         const fields = this.data.map((field) => new Field(field.tag, field.value));
         const data = [];
 
-        let beginString = new Field(BeginString, DEFAULT_FIX_VERSION).toString();
+        const beginString = new Field(BeginString, this.fixVersion).toString();
         let bodyLength = new Field(BodyLength, MARKER_BODYLENGTH).toString();
         let checksum = new Field(CheckSum, MARKER_CHECKSUM).toString();
-        let index = fields.findIndex((field) => field.tag === BeginString);
-
-        // Check for header
-        if(index > -1) {
-            beginString = fields[index].toString();
-            fields.splice(index, 1);
-        }
 
         // Check for body length
-        index = fields.findIndex((field) => field.tag === BodyLength);
+       let index = fields.findIndex((field) => field.tag === BodyLength);
         if(index > -1) {
             bodyLength = fields[index].toString();
             fields.splice(index, 1);


### PR DESCRIPTION
- Set the FIX protocol version on connect method, so that **startHeartbeat** method could use it as well, instead of using the default '**FIX.5.0SP2**' (resulting in wrong BeginString error and thus terminating the connection to server) even though the user chose otherwise.

- Since all connect method params are optional, switched to _named parameters_ in order not to write 'undefined' for params you don't need.